### PR TITLE
Fix broken download link for Linux Ubuntu 14.04

### DIFF
--- a/install.js
+++ b/install.js
@@ -23,7 +23,7 @@ var url = require('url')
 var util = require('util')
 var which = require('which')
 
-var cdnUrl = process.env.PHANTOMJS_CDNURL || 'https://github.com/bprodoehl/phantomjs/releases/download/'
+var cdnUrl = process.env.PHANTOMJS_CDNURL || 'https://github.com/bprodoehl/phantomjs/releases/download/v'
 var downloadUrl = cdnUrl + helper.version + '/phantomjs-' + helper.version + '-'
 
 var originalPath = process.env.PATH
@@ -106,7 +106,7 @@ whichDeferred.promise
 
     // Can't use a global version so start a download.
     if (process.platform === 'linux' && process.arch === 'x64') {
-      downloadUrl += 'linux-x86_64.zip'
+      downloadUrl += 'u1404-x86_64.zip'
     } else if (process.platform === 'darwin' || process.platform === 'openbsd' || process.platform === 'freebsd') {
       downloadUrl += 'macosx.zip'
     } else {


### PR DESCRIPTION
Hey,

**DON'T MERGE THIS**

It needs to be properly fixed up; I would have raised an issue but can't on a fork. I dunno how to check between different version of Ubuntu on Linux, and it's also annoying that [bprodoehl prefixed his latest release with 'v'](https://github.com/bprodoehl/phantomjs/releases/); those two things need to be handled and then this fix can go in.

Needed as currently this package fails to install on Linux. (at least on Ubuntu 14.04).

Cheers
