### PR TITLE
install.js should not check for exact same version

### DIFF
--- a/install.js
+++ b/install.js
@@ -83,8 +83,8 @@ whichDeferred.promise
     }
   })
   .then(function (stdout) {
-    var version = stdout.trim()
-    if (helper.version == version) {
+    var versionRe = new RegExp(stdout.trim());
+    if (versionRe.test(helper.version)) {
       writeLocationFile(phantomPath);
       console.log('PhantomJS is already installed at', phantomPath + '.')
       exit(0)


### PR DESCRIPTION
When you already have PhantomJS 2.0.0 installed, the installation process does not recognize it as installed. It compares the exact version but PhantomJS does only return `2.0.0`, not the appendix that @bprodoehl adds to his releases.

Checking for the major version should be sufficient.
