### PR TITLE
Updated ncp to 2.0.0 and kew to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   },
   "dependencies": {
     "adm-zip": "0.4.4",
-    "kew": "0.4.0",
-    "ncp": "~1.0.1",
+    "kew": "0.7.0",
+    "ncp": "~2.0.0",
     "npmconf": "2.0.9",
     "mkdirp": "0.5.0",
     "progress": "1.1.8",


### PR DESCRIPTION
This fixes an issue for me where the install script hangs at "Copying extracted folder"
