### PR TITLE
Reinstate script for piping streams to phantomjs binary

### DIFF
--- a/bin/phantomjs
+++ b/bin/phantomjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+/**
+ * Script that will execute the downloaded phantomjs binary.  stdio are
+ * forwarded to and from the child process.
+ *
+ * The following is for an ugly hack to avoid a problem where the installer
+ * finds the bin script npm creates during global installation.
+ *
+ * {NPM_INSTALL_MARKER}
+ */
+
+var path = require('path')
+var spawn = require('child_process').spawn
+
+var binPath = require(path.join(__dirname, '..', 'lib', 'phantomjs')).path
+
+var args = process.argv.slice(2)
+
+// For Node 0.6 compatibility, pipe the streams manually, instead of using
+// `{ stdio: 'inherit' }`.
+var cp = spawn(binPath, args)
+cp.stdout.pipe(process.stdout)
+cp.stderr.pipe(process.stderr)
+process.stdin.pipe(cp.stdin)
+
+cp.on('error', function (err) {
+  console.error('Error executing phantom at', binPath)
+  console.error(err.stack)
+})
+
+cp.on('exit', function(code){
+  // Wait few ms for error to be printed.
+  setTimeout(function(){
+    process.exit(code)
+  }, 20)
+});
+
+process.on('SIGTERM', function() {
+  cp.kill('SIGTERM')
+  process.exit(1)
+})

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "main": "lib/phantomjs",
   "bin": {
-    "phantomjs": "./lib/phantomjs/bin/phantomjs"
+    "phantomjs": "./bin/phantomjs"
   },
   "scripts": {
     "install": "node install.js",


### PR DESCRIPTION
I left a comment here https://github.com/zeevl/phantomjs2/commit/a642166a21d07d3ab82c6096f4d651fbdff3ed95#commitcomment-14551908

Basically, I had troubling installing this package because `bin` in `package.json` points to a non-existant file. npm complains, preventing the install script from executing (which needs to happen in order to download and extract the binary file).

As I hinted in my original comment, I wasn't sure about your original intention. Please close this if you think it is not the right approach. :)
