### PR TITLE
Fix path to binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "main": "lib/phantomjs",
   "bin": {
-    "phantomjs": "./lib/phantomjs/bin/phantomjs"
+    "phantomjs": "./lib/phantom/bin/phantomjs"
   },
   "scripts": {
     "install": "node install.js",


### PR DESCRIPTION
I got an `ENOENT` during installation. Seems like this is the proper path.

```
npm ERR! Windows_NT 6.3.9600
npm ERR! argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\OliverSalzburg\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js" "i"
npm ERR! node v4.2.1
npm ERR! npm  v3.3.10
npm ERR! path C:\Users\OliverSalzburg\Projects\absync\node_modules\phantomjs2\lib\phantomjs\bin\phantomjs
npm ERR! code ENOENT
npm ERR! errno -4058
npm ERR! syscall chmod

npm ERR! enoent ENOENT: no such file or directory, chmod 'C:\Users\OliverSalzburg\Projects\absync\node_modules\phantomjs2\lib\phantomjs\bin\phantomjs'
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent
```
