### PR TITLE
Use 2.0.1 binary provided by vitalilum so that it works with El Capitan

### DIFF
--- a/install.js
+++ b/install.js
@@ -352,22 +352,14 @@ function getDownloadUrl() {
 
   var cdnUrl = process.env.npm_config_phantomjs_cdnurl ||
       process.env.PHANTOMJS_CDNURL ||
-      'https://bitbucket.org/ariya/phantomjs/downloads'
+      'https://github.com/Vitallium/phantomjs/releases/download'
 
-  downloadUrl = cdnUrl + '/phantomjs-' + helper.version + '-'
+  downloadUrl = cdnUrl + '/' + helper.version + '/phantomjs-' + helper.version + '-'
 
   if (process.platform === 'linux' && process.arch === 'x64') {
-    downloadUrl += 'linux-x86_64.tar.bz2'
-  } else if (process.platform === 'linux' && process.arch == 'ia32') {
-    downloadUrl += 'linux-i686.tar.bz2'
+    downloadUrl += 'linux-x86_64.zip'
   } else if (process.platform === 'darwin' || process.platform === 'openbsd' || process.platform === 'freebsd') {
     downloadUrl += 'macosx.zip'
-
-    // workaround for os-x yosemite, where ariya's build is broken
-    // see https://github.com/ariya/phantomjs/issues/12928
-    if (parseInt(os.release()) >= 14)
-      downloadUrl = 'https://github.com/eugene1g/phantomjs/releases/download/2.0.0-bin/phantomjs-2.0.0-macosx.zip'
-
   } else if (process.platform === 'win32') {
     downloadUrl += 'windows.zip'
   } else {

--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -26,7 +26,7 @@ try {
  * The version of phantomjs installed by this package.
  * @type {number}
  */
-exports.version = '2.0.0'
+exports.version = '2.0.1'
 
 
 /**


### PR DESCRIPTION
So it seems 2.0.0 build doesn't work in El Capitan (not even with the build provided by @eugene1g). https://github.com/Homebrew/homebrew/issues/42249 provides some background information. It suggests that we could try the 2.0.1 build provided by @Vitallium. That build is currently used by Homebrew since this commit (https://github.com/Homebrew/homebrew/commit/ad499f9104ba5bb065941b8784c164d2f4016da7).
